### PR TITLE
Changed the progress-block class to use a calculated width of 8.5rem …

### DIFF
--- a/webui/style.css
+++ b/webui/style.css
@@ -1117,7 +1117,7 @@ table.table-hidecheck tbody > tr > td:first-child {
 /* BEGIN: Progress bars */
 .progress-block {
 	position: relative;
-	width: 120px;
+	width: calc(8.5rem);
 }
 
 .progress {


### PR DESCRIPTION
…instead of hardcoded 120px because larger file sizes cause text to overlap/cram